### PR TITLE
M17: Basic squelch-driven sampling gate

### DIFF
--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -248,6 +248,21 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         // Determine effective squelch
         bool sqOpen = (rfSqlOpen || now < squelchHoldUntil);
         // Manage baseband sampling based on effective squelch
+    // Manage baseband sampling based on effective squelch
+    if(rfSqlOpen) {
+        if(!samplingActive) {
+            demodulator.startBasebandSampling();
+            samplingActive = true;
+        }
+    } else {
+        if(samplingActive) {
+            demodulator.stopBasebandSampling();
+            samplingActive = false;
+        }
+        // No sampling -> skip DSP processing
+        return;
+    }
+
     bool newData = demodulator.update(invertRxPhase);
     bool lock    = demodulator.isLocked();
 


### PR DESCRIPTION
### Incremental change

This MR implements the first step of squelch-driven gating:

- When squelch opens, starts baseband sampling.
- When squelch closes, stops sampling and immediately returns before DSP.

This should eliminate most of the always-on DSP work when no RF signal is present, while leaving the rest of the RX loop untouched.

<hr>

Please test this minimal gate and let me know if inbound RF still works correctly. We'll add throttling and audio-path gating in follow-up steps once this gate is confirmed.
