### PR TITLE
build: stub out hwconfig.h for out-of-tree syntax-only builds

### DIFF
--- a/openrtx/include/hwconfig.h
+++ b/openrtx/include/hwconfig.h
@@ -1,0 +1,13 @@
+/*
+ * Fallback stub for hwconfig.h to allow out-of-tree
+ * syntax-only and manual g++ builds to succeed.
+ * Real hardware builds provide a board-specific hwconfig.h
+ * via platform/targets/<BOARD>/hwconfig.h.
+ */
+
+#ifndef HWCONFIG_H
+#define HWCONFIG_H
+
+// Empty stub: real hwconfig should define board-specific settings here.
+
+#endif /* HWCONFIG_H */


### PR DESCRIPTION
### Summary

This patch adds a stub `hwconfig.h` in `openrtx/include/` so that out-of-tree, syntax-only or manual `g++ -fsyntax-only` builds do not fail due to missing board-specific `hwconfig.h`. Real firmware builds (Meson/CMake + Zephyr) will continue to use the platform's `hwconfig.h` under `platform/targets/<BOARD>/`.

#### Why
- Prevents compiler errors when doing out-of-tree checks or IDE indexing on the core OpenRTX sources without a full build setup.
- No impact on actual firmware behavior; stub is empty.

#### Changes
- `openrtx/include/hwconfig.h`: empty stub with include guards.

#### Testing
- Manual `g++ -Iopenrtx/include … -fsyntax-only openrtx/src/rtx/OpMode_M17.cpp` now succeeds.
- Existing Meson and CMake builds for real boards remain unaffected.

Closes: N/A

---

If a PR template exists, adapt to that format.