### PR TITLE
M17: Improve squelch gating to honor hold timeout

### DIFF
--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -207,6 +207,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
     {
         // Ensure radio is enabled, sampling will start on squelch open
         radio_enableRx();
+        rfPowered = true;
         startRx = false;
         samplingActive = false;
     }
@@ -249,7 +250,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         bool sqOpen = (rfSqlOpen || now < squelchHoldUntil);
         // Manage baseband sampling based on effective squelch
     // Manage baseband sampling based on effective squelch
-    if(rfSqlOpen) {
+    if (sqOpen) {
         if(!samplingActive) {
             demodulator.startBasebandSampling();
             samplingActive = true;


### PR DESCRIPTION
## Description

This PR refines the M17 squelch gating logic so that baseband sampling and DSP processing only occur when the squelch is effectively open (`sqOpen`), which includes the squelch hold timeout. Additionally, on initial reception start (`startRx`), the RF front-end power state is set to `true` to match subsequent duty-cycle logic.

### Changes
- In `OpMode_M17::rxState`, under the `startRx` block:
  - Set `rfPowered = true;` after enabling Rx to ensure consistent front-end state.
- Replace sampling gate based solely on `rfSqlOpen` with `sqOpen`, which considers hold timeout (`squelchHoldUntil`).

## Motivation and Context
Previously, baseband sampling would stop immediately when `rfSqlOpen` closed, ignoring the hold timeout. This change prevents unnecessary power cycling and DSP workload during short fades when the hold timeout is active.

## How Has This Been Tested?
Manually verified on hardware that RF receive and DSP only activate on squelch break and honor the hold timeout.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes (if applicable).
- [ ] I have updated the documentation (if necessary).
- [x] All new and existing tests passed.
